### PR TITLE
refactor: map mongo document types to return correctly defined graphql object type

### DIFF
--- a/apps/server/src/modules/charge/utils/formatChargeDocumentForChargeObjectType.ts
+++ b/apps/server/src/modules/charge/utils/formatChargeDocumentForChargeObjectType.ts
@@ -1,0 +1,13 @@
+import { Charge } from "../dtos/entities/Charge";
+import { ChargeDocument } from "../models/ChargeModel";
+
+export const formatChargeDocumentForChargeObjectType = (
+  chargeDocument: ChargeDocument
+): Charge => {
+  return {
+    id: chargeDocument.id,
+    value: chargeDocument.value,
+    collaboratorsQuantity: chargeDocument.collaboratorsQuantity,
+    status: chargeDocument.status,
+  };
+};


### PR DESCRIPTION
- ChargeResolver was returning ChargeDocument type (mongodb) in queries/mutation with Charge type (graphql schema), and this PR solve it